### PR TITLE
fix(workflow): ignore untracked artifacts when checking ledger updates

### DIFF
--- a/.github/workflows/security-data-pipeline.yml
+++ b/.github/workflows/security-data-pipeline.yml
@@ -57,15 +57,19 @@ jobs:
       # [GIT OPS] 충돌 방지 및 원장 동기화 (Smart Sync V2)
       - name: Commit & Smart Sync (Stash Strategy)
         run: |
+          shopt -s nullglob
           git config --global user.name "Control-M-Bot"
           git config --global user.email "bot@grand-ops.enterprise"
           
           # 1. DB 및 키 파일 강제 스테이징 (중요 데이터)
           # veritas_vault는 용량이 크므로 gitignore 대상이지만, DB 파일 자체는 동기화
-          git add -f data/*.db config/*.key
+          LEDGER_FILES=(data/*.db config/*.key)
+          if [ ${#LEDGER_FILES[@]} -gt 0 ]; then
+            git add -f "${LEDGER_FILES[@]}"
+          fi
           
-          # 변경사항 체크
-          if [ -z "$(git status --porcelain)" ]; then
+          # 스테이징된 변경사항 체크 (로그/아티팩트 등 Untracked 파일은 무시)
+          if git diff --cached --quiet; then
              echo "✅ No ledger updates to sync."
              exit 0
           fi


### PR DESCRIPTION
### Motivation
- The workflow was failing when only untracked runtime artifacts (e.g. `ctm_logs/*.log`, `veritas_vault/*.gz`) existed, because `git status --porcelain` detected untracked files and a subsequent `git commit` ran with no staged changes and exited with code 1. 
- The intent is to ensure the job only attempts to commit when actual ledger files (DB/key) are staged, and to avoid brittle glob behavior when optional files are absent.

### Description
- Updated `.github/workflows/security-data-pipeline.yml` to enable `nullglob` and collect ledger targets into a `LEDGER_FILES` array before adding, so missing globs do not add literal patterns. 
- Replaced the working-tree check with a staged-only guard using `git diff --cached --quiet` so untracked artifacts are ignored and commits only occur when staged ledger files exist.

### Testing
- Ran `git show --stat --oneline HEAD` to confirm the commit was created, and it succeeded. 
- Ran `git diff --check HEAD~1..HEAD && git status --short` to validate there are no diff-check issues and the working tree state, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a42d169b88832396aa2cde425b845a)